### PR TITLE
Fix CSS class for custom Markdown in Directory (custom_pages 1.0.3)

### DIFF
--- a/views/global/markdown.php
+++ b/views/global/markdown.php
@@ -9,7 +9,8 @@ use humhub\libs\Html;
 $cssClass = ($page->hasAttribute('cssClass') && !empty($page->cssClass)) ? $page->cssClass : 'custom-pages-page';
 ?>
 
-<?php if ($page->hasTarget(Page::NAV_CLASS_ACCOUNTNAV)): ?>
+<?php if ($page->hasTarget(Page::NAV_CLASS_ACCOUNTNAV) ||
+          $page->hasTarget(Page::NAV_CLASS_DIRECTORY)): ?>
     <div class="panel panel-default <?= Html::encode($cssClass) ?>">
         <div class="panel-body">
             <?= RichText::output($md)?>


### PR DESCRIPTION
Markdown content was receiving the 'container' CSS class and overflowing
the page width when attached to a Directory Menu item. Fix this by using
the same layout as when attached to the User Account Menu.