### PR TITLE
Global PHP page lost on update #143

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,7 +5,13 @@ Changelog
 1.0.11 (Unreleased)
 -------------------
 - Fix #121: Link color in markdown pages have same color as text
-
+- Fix #143: Global PHP page lost on update. The folder views/custom was deleted and the path to php custom pages changed
+            Needed manually create this directories for PHP custom pages:
+                    php-pages/container_pages/
+                    php-pages/container_snippets/
+                    php-pages/global_pages/
+                    php-pages/global_snippets/ 
+            As recommendation please consider to put these directories in protected/modules/module_data/custom_pages/ 
 
 1.0.10 (September 19, 2020)
 --------------------

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,14 +4,13 @@ Changelog
 
 1.0.11 (Unreleased)
 -------------------
+
+The default folders for PHP custom pages were changed.
+New defaults: php-pages/container_pages/, php-pages/container_snippets/, php-pages/global_pages/, php-pages/global_snippets/ 
+
 - Fix #121: Link color in markdown pages have same color as text
-- Fix #143: Global PHP page lost on update. The folder views/custom was deleted and the path to php custom pages changed
-            Needed manually create this directories for PHP custom pages:
-                    php-pages/container_pages/
-                    php-pages/container_snippets/
-                    php-pages/global_pages/
-                    php-pages/global_snippets/ 
-            As recommendation please consider to put these directories in protected/modules/module_data/custom_pages/ 
+- Fix #143: (Global) PHP pages were lost on module updates
+
 
 1.0.10 (September 19, 2020)
 --------------------

--- a/models/forms/SettingsForm.php
+++ b/models/forms/SettingsForm.php
@@ -14,10 +14,10 @@ use yii\base\Model;
 
 class SettingsForm extends Model
 {
-    const DEFAULT_VIEW_PATH_PAGES = '@custom_pages/views/custom/global_pages/';
-    const DEFAULT_VIEW_PATH_SNIPPETS = '@custom_pages/views/custom/global_snippets/';
-    const DEFAULT_VIEW_PATH_CONTAINER_PAGES = '@custom_pages/views/custom/container_pages/';
-    const DEFAULT_VIEW_PATH_CONTAINER_SNIPPETS = '@custom_pages/views/custom/container_snippets/';
+    const DEFAULT_VIEW_PATH_PAGES = '@webroot/php-pages/global_pages/';
+    const DEFAULT_VIEW_PATH_SNIPPETS = '@webroot/php-pages/global_snippets/';
+    const DEFAULT_VIEW_PATH_CONTAINER_PAGES = '@webroot/php-pages/container_pages/';
+    const DEFAULT_VIEW_PATH_CONTAINER_SNIPPETS = '@webroot/php-pages/container_snippets/';
 
     /**
      * @var integer

--- a/models/forms/SettingsForm.php
+++ b/models/forms/SettingsForm.php
@@ -75,7 +75,7 @@ class SettingsForm extends Model
 
     public function validateViewPath($attribute, $params)
     {
-        if(!is_dir(Yii::getAlias($this->$attribute))) {
+        if(!is_dir(Yii::getAlias($this->$attribute)) && $this->phpPagesActive) {
             $this->addError($attribute, Yii::t('CustomPagesModule.models_SettignsForm', 'The given view file path does not exist.'));
         }
     }

--- a/module.json
+++ b/module.json
@@ -3,7 +3,7 @@
     "name": "Custom Pages",
     "description": "Allows admins to create custom pages (html or markdown) or external links to various navigations (e.g. top navigation, account menu).",
     "keywords": ["pages", "custom", "iframe", "markdown", "link", "navigation", "spaces"],
-    "version": "1.0.10",
+    "version": "1.0.11",
     "humhub": {
         "minVersion": "1.3.10"
     }

--- a/views/custom/container_pages/.gitignore
+++ b/views/custom/container_pages/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/views/custom/container_snippets/.gitignore
+++ b/views/custom/container_snippets/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/views/custom/global_pages/.gitignore
+++ b/views/custom/global_pages/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/views/custom/global_snippets/.gitignore
+++ b/views/custom/global_snippets/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore


### PR DESCRIPTION
1) Move directory **custom_pages/views/custom** to root as **php-pages** directory to keep custom PHP files and preserve them from deleting during custom_pages module update.
2) Changed settings in **SettingsForm**

This pull request connected with:
https://github.com/humhub/humhub/pull/4544

