### PR TITLE
Remove extraneous ?>

### DIFF
--- a/modules/template/widgets/views/collapsableFormGroup.php
+++ b/modules/template/widgets/views/collapsableFormGroup.php
@@ -49,4 +49,3 @@ use humhub\libs\Html; ?>
         }
     });
 <?= Html::endTag('script') ?>
-?>


### PR DESCRIPTION
This misplaced piece of syntax was being rendered literally after the
CollapsableFormGroup.